### PR TITLE
2026-07-20_19:07:17 linux clang and webassembly builds

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -28,7 +28,15 @@ jobs:
       matrix:
         include:
           - os: ubuntu-26.04
-            preset: linux-release
+            preset: linux-gcc-release
+            is_cygwin: false
+            exhaustive: false
+          - os: ubuntu-26.04
+            preset: linux-clang-release
+            is_cygwin: false
+            exhaustive: false
+          - os: ubuntu-26.04
+            preset: wasm-release
             is_cygwin: false
             exhaustive: false
           - os: windows-latest
@@ -57,16 +65,27 @@ jobs:
           github.event_name == 'schedule' ||
           (github.event_name == 'workflow_dispatch' && inputs.run_exhaustive == true)
 
-
 # Linux setup
 
       - name: Linux setup
         if: matrix.os == 'ubuntu-26.04'
         run: |
           sudo apt update
-          sudo apt install -y gcc-16 g++-16 cmake ninja-build bison flex libfl-dev
-          echo "CC=gcc-16" >> $GITHUB_ENV
-          echo "CXX=g++-16" >> $GITHUB_ENV
+          sudo apt install -y ninja-build bison flex libfl-dev
+          sudo snap install cmake --classic
+          if [[ ${{ matrix.preset }} == linux-gcc-* ]]; then
+            sudo apt install -y gcc-16 g++-16
+            echo "CC=gcc-16" >> $GITHUB_ENV
+            echo "CXX=g++-16" >> $GITHUB_ENV
+          elif [[ ${{ matrix.preset }} == linux-clang-* ]]; then
+            sudo apt install -y clang-22 lld-22
+            echo "CC=clang-22" >> $GITHUB_ENV
+            echo "CXX=clang++-22" >> $GITHUB_ENV
+          elif [[ ${{ matrix.preset }} == linux-wasm-* ]]; then
+            sudo apt install -y clang-22 lld-22
+            echo "CC=clang-22" >> $GITHUB_ENV
+            echo "CXX=clang++-22" >> $GITHUB_ENV
+          fi
 
       - name: Linux versions
         if: matrix.os == 'ubuntu-26.04'
@@ -76,9 +95,6 @@ jobs:
           uname -a
           echo "lsb_release -a"
           lsb_release -a
-          echo "gcc --version"
-          gcc-16 --version
-          g++-16 --version
           echo "cmake --version"
           cmake --version
           echo "bison --version"
@@ -87,6 +103,23 @@ jobs:
           flex --version
           echo "ls -l FlexLexer.h"
           ls -l /usr/include/FlexLexer.h
+          if [[ ${{ matrix.preset }} == linux-gcc-* ]]; then
+            echo "gcc --version"
+            gcc-16 --version
+            g++-16 --version
+          elif [[ ${{ matrix.preset }} == linux-clang-* ]]; then
+            echo "clang --version"
+            clang-22 --version
+            clang++-22 --version
+          fi
+
+# Webassembly setup
+
+      - name: Webassembly setup
+        if: matrix.preset == 'linux-wasm-release'
+        uses: emscripten-core/setup-emsdk@v16
+        with:
+          version: 'latest'
 
 # Windows setup
 
@@ -128,19 +161,27 @@ jobs:
           $(brew --prefix flex)/bin/flex --version
           echo "ls -l FlexLexer.h"
           ls -l $(brew --prefix flex)/include/FlexLexer.h
+          echo "gcc --version"
+          gcc-16 --version
+          g++-16 --version
 
 # Non-Cygwin build and test
 
       - name: CMake Configure
         if: matrix.is_cygwin == false
-        run: cmake --preset ${{ matrix.preset }}
+        run: |
+          if [[ ${{ matrix.preset }} == linux-wasm-* ]]; then
+            emcmake cmake --preset ${{ matrix.preset }}
+          else
+            cmake --preset ${{ matrix.preset }}
+          fi
 
       - name: Build
         if: matrix.is_cygwin == false
         run: cmake --build --preset ${{ matrix.preset }}
 
       - name: Run Tests
-        if: matrix.is_cygwin == false
+        if: matrix.is_cygwin == false && matrix.preset != 'linux-wasm-release'
         run: ctest --preset ${{ matrix.preset }} --output-on-failure
 
 # Cygwin setup

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -168,11 +168,11 @@ jobs:
 # Non-Cygwin build and test
 
       - name: CMake Configure
-        if: matrix.is_cygwin == false && matrix.preset != linux-wasm-release
+        if: matrix.is_cygwin == false && matrix.preset != 'linux-wasm-release'
         run: cmake --preset ${{ matrix.preset }}
 
       - name: Webassembly CMake Configure
-        if: matrix.is_cygwin == false && matrix.preset == linux-wasm-release
+        if: matrix.is_cygwin == false && matrix.preset == 'linux-wasm-release'
         run: emcmake cmake --preset ${{ matrix.preset }}
 
       - name: Build

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -36,7 +36,7 @@ jobs:
             is_cygwin: false
             exhaustive: false
           - os: ubuntu-26.04
-            preset: wasm-release
+            preset: linux-wasm-release
             is_cygwin: false
             exhaustive: false
           - os: windows-latest
@@ -168,13 +168,12 @@ jobs:
 # Non-Cygwin build and test
 
       - name: CMake Configure
-        if: matrix.is_cygwin == false
-        run: |
-          if [[ ${{ matrix.preset }} == linux-wasm-* ]]; then
-            emcmake cmake --preset ${{ matrix.preset }}
-          else
-            cmake --preset ${{ matrix.preset }}
-          fi
+        if: matrix.is_cygwin == false && matrix.preset != linux-wasm-release
+        run: cmake --preset ${{ matrix.preset }}
+
+      - name: Webassembly CMake Configure
+        if: matrix.is_cygwin == false && matrix.preset == linux-wasm-release
+        run: emcmake cmake --preset ${{ matrix.preset }}
 
       - name: Build
         if: matrix.is_cygwin == false

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -109,20 +109,20 @@
       }
     },
     {
-      "name": "wasm-debug",
+      "name": "linux-wasm-debug",
       "$comment": "Webassembly debug build",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build/wasm-debug",
+      "binaryDir": "${sourceDir}/build/linux-wasm-debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_CXX_EXTENSIONS": "OFF"
       }
     },
     {
-      "name": "wasm-release",
+      "name": "linux-wasm-release",
       "$comment": "Webassembly release build",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build/wasm-release",
+      "binaryDir": "${sourceDir}/build/linux-wasm-release",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CXX_EXTENSIONS": "OFF"
@@ -171,12 +171,12 @@
       "configurePreset": "mac-debug"
     },
     {
-      "name": "wasm-debug",
-      "configurePreset": "wasm-debug"
+      "name": "linux-wasm-debug",
+      "configurePreset": "linux-wasm-debug"
     },
     {
-      "name": "wasm-release",
-      "configurePreset": "wasm-release"
+      "name": "linux-wasm-release",
+      "configurePreset": "linux-wasm-release"
     }
   ],
   "testPresets": [
@@ -223,12 +223,12 @@
       "configurePreset": "mac-debug"
     },
     {
-      "name": "wasm-debug",
-      "configurePreset": "wasm-debug"
+      "name": "linux-wasm-debug",
+      "configurePreset": "linux-wasm-debug"
     },
     {
-      "name": "wasm-release",
-      "configurePreset": "wasm-release"
+      "name": "linux-wasm-release",
+      "configurePreset": "linux-wasm-release"
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,10 +3,10 @@
   "$comment": "ebnfparser cmake presets",
   "configurePresets": [
     {
-      "name": "linux-release",
+      "name": "linux-gcc-release",
       "$comment": "Linux GCC release build",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build/linux-release",
+      "binaryDir": "${sourceDir}/build/linux-gcc-release",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_CXX_COMPILER": "/usr/bin/g++-16",
@@ -14,14 +14,38 @@
       }
     },
     {
-      "name": "linux-debug",
+      "name": "linux-gcc-debug",
       "$comment": "Linux GCC debug build",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build/linux-debug",
+      "binaryDir": "${sourceDir}/build/linux-gcc-debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_CXX_COMPILER": "/usr/bin/g++-16",
         "CMAKE_C_COMPILER": "/usr/bin/gcc-16"
+      }
+    },
+    {
+      "name": "linux-clang-debug",
+      "$comment": "Linux Clang debug build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/linux-clang-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "clang-22",
+        "CMAKE_CXX_COMPILER": "clang++-22",
+        "CMAKE_EXE_LINKER_FLAGS_INIT": "-fuse-ld=lld"
+      }
+    },
+    {
+      "name": "linux-clang-release",
+      "$comment": "Linux Clang release build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/linux-clang-release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_C_COMPILER": "clang-22",
+        "CMAKE_CXX_COMPILER": "clang++-22",
+        "CMAKE_EXE_LINKER_FLAGS_INIT": "-fuse-ld=lld"
       }
     },
     {
@@ -64,7 +88,7 @@
     },
     {
       "name": "mac-release",
-      "$comment": "Mac GCC release build",
+      "$comment": "Mac Clang release build",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/mac-release",
       "cacheVariables": {
@@ -75,7 +99,7 @@
     },
     {
       "name": "mac-debug",
-      "$comment": "Mac GCC debug build",
+      "$comment": "Mac Clang debug build",
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/build/mac-debug",
       "cacheVariables": {
@@ -83,16 +107,44 @@
         "BISON_EXECUTABLE": "$env{BISON_ROOT}/bin/bison",
         "FLEX_EXECUTABLE": "$env{FLEX_ROOT}/bin/flex"
       }
+    },
+    {
+      "name": "wasm-debug",
+      "$comment": "Webassembly debug build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/wasm-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_EXTENSIONS": "OFF"
+      }
+    },
+    {
+      "name": "wasm-release",
+      "$comment": "Webassembly release build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/wasm-release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_EXTENSIONS": "OFF"
+      }
     }
   ],
   "buildPresets": [
     {
-      "name": "linux-release",
-      "configurePreset": "linux-release"
+      "name": "linux-gcc-release",
+      "configurePreset": "linux-gcc-release"
     },
     {
-      "name": "linux-debug",
-      "configurePreset": "linux-debug"
+      "name": "linux-gcc-debug",
+      "configurePreset": "linux-gcc-debug"
+    },
+    {
+      "name": "linux-clang-release",
+      "configurePreset": "linux-clang-release"
+    },
+    {
+      "name": "linux-clang-debug",
+      "configurePreset": "linux-clang-debug"
     },
     {
       "name": "windows-release",
@@ -117,16 +169,32 @@
     {
       "name": "mac-debug",
       "configurePreset": "mac-debug"
+    },
+    {
+      "name": "wasm-debug",
+      "configurePreset": "wasm-debug"
+    },
+    {
+      "name": "wasm-release",
+      "configurePreset": "wasm-release"
     }
   ],
   "testPresets": [
     {
-      "name": "linux-release",
-      "configurePreset": "linux-release"
+      "name": "linux-gcc-release",
+      "configurePreset": "linux-gcc-release"
     },
     {
-      "name": "linux-debug",
-      "configurePreset": "linux-debug"
+      "name": "linux-gcc-debug",
+      "configurePreset": "linux-gcc-debug"
+    },
+    {
+      "name": "linux-clang-release",
+      "configurePreset": "linux-clang-release"
+    },
+    {
+      "name": "linux-clang-debug",
+      "configurePreset": "linux-clang-debug"
     },
     {
       "name": "windows-release",
@@ -153,6 +221,14 @@
     {
       "name": "mac-debug",
       "configurePreset": "mac-debug"
+    },
+    {
+      "name": "wasm-debug",
+      "configurePreset": "wasm-debug"
+    },
+    {
+      "name": "wasm-release",
+      "configurePreset": "wasm-release"
     }
   ]
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,12 +2,13 @@
 
 project(ebnfparser_src)
 
-if(NOT WIN32)
-  message("Generate bison, flex files from src/grammar")
-  add_subdirectory(grammar)
-else()
+# don't run bison, flex for windows and webassembly builds
+if(WIN32 OR EMSCRIPTEN)
   message("Use checked-in generated bison, flex files from src/flexbison.gen")
   add_subdirectory(flexbison.gen)
+else()
+  message("Generate bison, flex files from src/grammar")
+  add_subdirectory(grammar)
 endif()
 
 add_subdirectory(parser)

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -2,6 +2,28 @@
 
 project(ebnf_ast)
 
+add_library(ebnfastlib INTERFACE)
+target_sources(ebnfastlib INTERFACE ebnf_ast.h)
+
+target_compile_definitions(ebnfastlib INTERFACE $<$<PLATFORM_ID:CYGWIN>: GTEST_HAS_PTHREAD=1 _POSIX_C_SOURCE=200809L _GNU_SOURCE>)
+
+target_compile_options(ebnfastlib INTERFACE
+  $<$<CXX_COMPILER_ID:GNU>: -std=c++26 -Wall -Werror -Wextra -pthread -fconcepts-diagnostics-depth=10>
+  $<$<CXX_COMPILER_ID:MSVC>: -std:c++latest -W4 -WX>
+  $<$<CXX_COMPILER_ID:Clang>: -Wall -Werror -Wextra -std=c++26 -pthread -Wno-unqualified-std-cast-call>
+)
+target_compile_options(ebnfastlib INTERFACE
+  $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:GNU>>: -O0 -ggdb3>
+  $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:GNU>>: -Og>
+  $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:MSVC>>: -Od -Zi>
+  $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:Clang>>: -O0 -ggdb3>
+  $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:Clang>>: -Og>
+)
+
+target_include_directories(ebnfastlib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+
+# tests
+
 add_executable(ebnf_ast.gtest ebnf_ast.gtest.cpp)
 
 target_compile_definitions(ebnf_ast.gtest PRIVATE $<$<PLATFORM_ID:CYGWIN>: GTEST_HAS_PTHREAD=1 _POSIX_C_SOURCE=200809L _GNU_SOURCE>)
@@ -9,14 +31,17 @@ target_compile_definitions(ebnf_ast.gtest PRIVATE $<$<PLATFORM_ID:CYGWIN>: GTEST
 target_compile_options(ebnf_ast.gtest PRIVATE
   $<$<CXX_COMPILER_ID:GNU>: -std=c++26 -Wall -Werror -Wextra -pthread -fconcepts-diagnostics-depth=10>
   $<$<CXX_COMPILER_ID:MSVC>: -std:c++latest -W4 -WX>
+  $<$<CXX_COMPILER_ID:Clang>: -Wall -Werror -Wextra -std=c++26 -pthread -Wno-unqualified-std-cast-call>
 )
 target_compile_options(ebnf_ast.gtest PRIVATE
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:GNU>>: -O0 -ggdb3>
   $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:GNU>>: -Og>
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:MSVC>>: -Od -Zi>
+  $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:Clang>>: -O0 -ggdb3>
+  $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:Clang>>: -Og>
 )
 
-target_link_libraries(ebnf_ast.gtest gmock_main)
+target_link_libraries(ebnf_ast.gtest ebnfastlib gmock_main)
 
 enable_testing()
 include(GoogleTest)

--- a/src/ast/ebnf_ast.h
+++ b/src/ast/ebnf_ast.h
@@ -30,6 +30,7 @@ SOFTWARE.
 #include <vector>
 #include <set>
 #include <flat_set>
+#include <initializer_list>
 #include <map>
 #include <variant>
 #include <compare>
@@ -42,59 +43,75 @@ SOFTWARE.
 namespace ebnfparser {
 using namespace std;
 
-struct Grammar;
-struct Header;
-struct Rule;
-struct Item;
-struct Repetition;
 struct AltBase;
 struct Alternative;
 struct Concatenation;
-struct Optional;
+struct Grammar;
 struct Group;
-struct CompareAlt;
+struct Header;
+struct Item;
+struct Optional;
+struct Repetition;
+struct Rule;
 
 using Symbol = string;
 using Nonterminal = Symbol;
 using Token = Symbol;
 using Literal = Symbol;
 
-struct Header {
-  vector<string> lines{};
-};
 
-struct Grammar {
-  Header header{};
-  vector<Rule> rules{};
-};
-
-struct Rule {
-  string nonterminal{};
-// hopefully flat_set is fast enough for iterative applications like convert to bnf that doesn't need lookup
-// could go back to vector<Alternative>
-  flat_set<Alternative> alts{};
-};
-
-struct Concatenation {
-  vector<Repetition> reps{};
-
-  strong_ordering operator<=>(const Concatenation& other) const = default;
-};
+// AltBase, base class for Alternative, Optional, Group
 
 struct AltBase {
-  flat_set<Concatenation> concats{};
+  flat_set<Concatenation> concats;
 
-  strong_ordering operator<=>(const AltBase& other) const = default;
+  strong_ordering operator<=>(const AltBase& other) const;
+  bool operator==(const AltBase& other) const = default;
+
 };
+
+// Alternative
 
 struct Alternative: public AltBase {
 };
 
+// Optional
+
 struct Optional: public AltBase {
 };
 
+// Group
+
 struct Group: public AltBase {
 };
+
+// Rule
+// may need to define constructors and destructors outside class if cyclic dependency errors can't be fixed by reordering class definitions
+// Rule(), Rule(string nt, initializer_list<Alternative> init), ~Rule()
+
+struct Rule {
+  string nonterminal{};
+
+// hopefully flat_set is fast enough for iterative applications like convert to bnf that doesn't need lookup
+// could go back to vector<Alternative>
+  flat_set<Alternative> alts;
+
+};
+
+// Header
+
+struct Header {
+  vector<string> lines{};
+};
+
+// Grammar
+
+struct Grammar {
+  Header header{};
+  vector<Rule> rules;
+};
+
+// Item
 
 struct Item: variant<Symbol, Optional, Group> {
   using variant::variant;
@@ -106,55 +123,27 @@ private:
   template<class... Ts> struct overload : Ts... { using Ts::operator()...; };
 };
 
+// Repetition
+
 struct Repetition { 
   bool isRepeated = false;
-  Item item{};
+  Item item;
 
   strong_ordering operator<=>(const Repetition& other) const = default;
 };
 
-inline
-strong_ordering Item::operator<=>(const Item& other) const {
+// Concatenation
 
-  if(index() != other.index()) {
-    return index() <=> other.index();
-  }
+struct Concatenation {
+  vector<Repetition> reps;
 
-// capture other because visit only takes overload as parameter
-// cannot pass second parameter to lambda overloads
-  return visit(overload{
+  strong_ordering operator<=>(const Concatenation& other) const;
+  bool operator==(const Concatenation& other) const = default;
 
-    [&other](const Symbol& s1) -> strong_ordering {
-      const auto& s2 = get<Symbol>(other);
-      return s1 <=> s2;
-    },
+};
 
-    [&other](const Optional& o1) -> strong_ordering {
-      const auto& o2 = get<Optional>(other);
-      return o1 <=> o2;
-    },
 
-    [&other](const Group& g1) -> strong_ordering {
-      const auto& g2 = get<Group>(other);
-      return g1 <=> g2;
-    },
-
-// default match
-    [](const auto&&) -> strong_ordering {
-      println("Item.spaceship: unexpected default match");
-      return {{}};
-    },
-
-// new c++26 variant visit member function, takes 1 parameter
-// old variant visit global function, takes 2 parameters
-#if __cpp_lib_variant >= 202306L
-  });
-#else
-  }, *this);
-#endif
-
-}
-
+// AstNode
 
 struct AstNode: variant<Grammar, Header, Rule, Alternative, Concatenation, Repetition, Optional, Item, Symbol, Group> {
   using variant::variant;
@@ -296,6 +285,33 @@ void AstNode::printAst() const {
   }, *this);
 #endif
 
+}
+
+// these must be defined outside class
+
+// Concatenation
+
+// for flat_set<Concatenation>
+inline
+strong_ordering Concatenation::operator<=>(const Concatenation& other) const {
+  return reps <=> other.reps;
+}
+
+// AltBase
+
+// for flat_set<Alternative>
+inline
+strong_ordering AltBase::operator<=>(const AltBase& other) const {
+  return concats <=> other.concats;
+}
+
+// Item
+
+// for flat_set<Alternative> and flat_set<Concatenation>
+inline
+strong_ordering Item::operator<=>(const Item& other) const {
+    return static_cast<const variant<Symbol, Optional, Group>&>(*this)
+      <=> static_cast<const variant<Symbol, Optional, Group>&>(other);
 }
 
 

--- a/src/ebnf_convert/CMakeLists.txt
+++ b/src/ebnf_convert/CMakeLists.txt
@@ -10,14 +10,17 @@ target_compile_definitions(ebnfconvert PRIVATE $<$<PLATFORM_ID:CYGWIN>: GTEST_HA
 target_compile_options(ebnfconvert PRIVATE
   $<$<CXX_COMPILER_ID:GNU>: -Wall -Werror -Wextra -std=c++26 -pthread -fconcepts-diagnostics-depth=10>
   $<$<CXX_COMPILER_ID:MSVC>: -std:c++latest -W4 -WX>
+  $<$<CXX_COMPILER_ID:Clang>: -Wall -Werror -Wextra -std=c++26 -pthread -Wno-unqualified-std-cast-call>
 )
 target_compile_options(ebnfconvert PRIVATE
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:GNU>>: -O0 -ggdb3>
   $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:GNU>>: -Og>
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:MSVC>>: -Od -Zi>
+  $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:Clang>>: -O0 -ggdb3>
+  $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:Clang>>: -Og>
 )
 
-target_link_libraries(ebnfconvert flexbisonlib.ebnfparser)
+target_link_libraries(ebnfconvert ebnfastlib flexbisonlib.ebnfparser)
 target_link_libraries(ebnfconvert $<$<CXX_COMPILER_ID:MSVC>:getoptlib>)
 
 # tests
@@ -28,11 +31,14 @@ target_compile_definitions(ebnf_convert.gtest PRIVATE $<$<PLATFORM_ID:CYGWIN>: G
 target_compile_options(ebnf_convert.gtest PRIVATE
   $<$<CXX_COMPILER_ID:GNU>: -Wall -Werror -Wextra -std=c++26 -pthread -fconcepts-diagnostics-depth=10>
   $<$<CXX_COMPILER_ID:MSVC>: -std:c++latest -W4 -WX>
+  $<$<CXX_COMPILER_ID:Clang>: -Wall -Werror -Wextra -std=c++26 -pthread -Wno-unqualified-std-cast-call>
 )
 target_compile_options(ebnf_convert.gtest PRIVATE
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:GNU>>: -O0 -ggdb3>
   $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:GNU>>: -Og>
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:MSVC>>: -Od -Zi>
+  $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:Clang>>: -O0 -ggdb3>
+  $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:Clang>>: -Og>
 )
 
 target_link_libraries(ebnf_convert.gtest flexbisonlib.ebnfparser gmock_main)

--- a/src/ebnf_convert/ebnf_convert.gtest.cpp
+++ b/src/ebnf_convert/ebnf_convert.gtest.cpp
@@ -36,7 +36,6 @@ SOFTWARE.
 #include "ebnf_parser.bison.h"
 
 using namespace std;
-using namespace ::testing;
 using namespace ebnfparser;
 
 namespace ebnfconvert::testing {

--- a/src/ebnf_convert/ebnf_convert.h
+++ b/src/ebnf_convert/ebnf_convert.h
@@ -61,22 +61,22 @@ struct BnfHeader {
 // Grammar is sequence of BnfRule
 struct BnfGrammar {
   BnfHeader header{};
-  vector<BnfRule> rules{};
+  vector<BnfRule> rules;
 };
 
 struct BnfRule {
   string nterm{};
-  vector<BnfChoice> choices{};
+  vector<BnfChoice> choices;
 };
 
 // BnfSequence is sequence of BnfSymbol
 struct BnfSequence {
-  vector<BnfSymbol> syms{};
+  vector<BnfSymbol> syms;
 };
 
 // BnfChoice is sequence of BnfSequence
 struct BnfChoice {
-  vector<BnfSequence> seqs{};
+  vector<BnfSequence> seqs;
 };
 
 struct BnfNode: variant<BnfGrammar, BnfHeader, BnfRule, BnfChoice, BnfSequence, BnfSymbol> {
@@ -318,7 +318,7 @@ BnfNode EbnfConvert::convert(const AstNode& ebnf) {
 
   auto ebnfOverload = overload{
 // grammar
-    [this](this auto&& self, const Grammar& g) -> BnfNode {
+    [](this auto&& self, const Grammar& g) -> BnfNode {
       BnfHeader header = get<BnfHeader>(self(g.header));
       vector<BnfRule> rules;
       for(auto& rule: g.rules) {
@@ -338,7 +338,7 @@ BnfNode EbnfConvert::convert(const AstNode& ebnf) {
     },
 
 // alternative
-    [altOverload](this auto&& self, const Alternative& a) -> BnfNode {
+    [altOverload](this auto&&, const Alternative& a) -> BnfNode {
       vector<BnfSequence> seqs;
       for(auto& concat: a.concats) {
         auto newChoice = altOverload(concat);

--- a/src/ebnf_convert/ebnf_convert.h
+++ b/src/ebnf_convert/ebnf_convert.h
@@ -91,21 +91,44 @@ private:
 
 struct EbnfConvert {
 
-// these started out as local variables in convert but got segv in vc++ with nested visit overload lambdas
-// it seems local captures in nested overload that is itself captured by outer overload end up pointing to invalid memory when inner overload actually runs
-// will need time-consuming debugging and investigation to check if it's a vc++ bug or undefined behavior that happens to work in gcc
-// difference might go away when vc++ implements c++26 variant visit member function
-
-  uint64_t numRulesParsed = 0;
-  uint64_t numRulesGenerated = 0;
-  int groupNum = 0;
-  int listNum = 0;
-  vector<BnfRule> newRules{};
+  struct Aux {
+    uint64_t numRulesParsed = 0;
+    uint64_t numRulesGenerated = 0;
+    int groupNum = 0;
+    int listNum = 0;
+    vector<BnfRule> newRules;
+  };
 
   BnfNode convert(const AstNode& ebnf);
 
 private:
-  template<class... Ts> struct overload: Ts... { using Ts::operator()...; };
+// vc++ seh exceptions crash without empty_bases attribute
+#if WIN32
+  template<class... Ts> struct __declspec(empty_bases) overload1: Ts... { using Ts::operator()...; };
+
+  template<class... Ts>
+  struct __declspec(empty_bases) overload2 : Ts... {
+    using Ts::operator()...;
+
+    int groupNum = 0;
+    int listNum = 0;
+    vector<BnfRule> newRules;
+  };
+#else
+  template<class... Ts> struct overload1: Ts... { using Ts::operator()...; };
+
+  template<class... Ts> struct overload2 : Ts... {
+    using Ts::operator()...;
+
+    int groupNum = 0;
+    int listNum = 0;
+    vector<BnfRule> newRules{};
+  };
+#endif
+
+// clang 22 and vc++ 2026 still need template deduction guides
+  template<class... Ts> overload1(Ts...) -> overload1<Ts...>;
+  template<class... Ts> overload2(Ts...) -> overload2<Ts...>;
 
 };
 
@@ -185,8 +208,10 @@ void BnfNode::printBnf() const {
 inline
 BnfNode EbnfConvert::convert(const AstNode& ebnf) {
 
+  Aux aux;
+
 // visit ebnf nodes inside alternative
-  auto altOverload = overload{
+  auto altOverload = overload2{
 
 // group
     [](this auto&& self, const Group& g) -> BnfChoice {
@@ -251,7 +276,8 @@ BnfNode EbnfConvert::convert(const AstNode& ebnf) {
     },
 
 // repetition
-    [this](this auto&& self, const Repetition& r) -> BnfChoice {
+    [&aux](this auto&& self, const Repetition& r) -> BnfChoice {
+      auto& [_, __, groupNum, listNum, newRules] = aux;
       auto result = self(r.item);
       if(!r.isRepeated) {
         return result;
@@ -315,8 +341,7 @@ BnfNode EbnfConvert::convert(const AstNode& ebnf) {
 
   };
 
-
-  auto ebnfOverload = overload{
+  auto ebnfOverload = overload1{
 // grammar
     [](this auto&& self, const Grammar& g) -> BnfNode {
       BnfHeader header = get<BnfHeader>(self(g.header));
@@ -379,7 +404,7 @@ BnfNode EbnfConvert::convert(const AstNode& ebnf) {
   auto result = visit(ebnfOverload, ebnf);
 #endif
   BnfGrammar bnf = get<BnfGrammar>(result);
-  bnf.rules.append_range(newRules);
+  bnf.rules.append_range(aux.newRules);
 
   return bnf;
 

--- a/src/flexbison.gen/CMakeLists.txt
+++ b/src/flexbison.gen/CMakeLists.txt
@@ -9,14 +9,22 @@ target_compile_definitions(flexbisonlib.ebnfparser PRIVATE $<$<PLATFORM_ID:CYGWI
 target_compile_options(flexbisonlib.ebnfparser PRIVATE
   $<$<CXX_COMPILER_ID:GNU>: -std=c++26 -Wall -Werror -Wextra -pthread -fconcepts-diagnostics-depth=10>
   $<$<CXX_COMPILER_ID:MSVC>: -std:c++latest -W4 -WX>
+  $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Emscripten>: -std=c++26 -Wall -Werror -Wextra -pthread -Wno-unqualified-std-cast-call>
 )
 target_compile_options(flexbisonlib.ebnfparser PRIVATE
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:GNU>>: -O0 -ggdb3>
   $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:GNU>>: -Og>
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:MSVC>>: -Od -Zi>
+  $<$<AND:$<CONFIG:debug>,$<STREQUAL:${CMAKE_SYSTEM_NAME},Emscripten>>: -O0 -ggdb3>
 )
 
-target_include_directories(flexbisonlib.ebnfparser PUBLIC ${CMAKE_SOURCE_DIR}/src)
-target_include_directories(flexbisonlib.ebnfparser PUBLIC . $<$<CXX_COMPILER_ID:MSVC>: ${CMAKE_SOURCE_DIR}/thirdparty/flex>)
+target_include_directories(flexbisonlib.ebnfparser PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_SOURCE_DIR}/src
+  $<$<CXX_COMPILER_ID:MSVC>: ${CMAKE_SOURCE_DIR}/thirdparty/flex>
+  $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Emscripten>: ${CMAKE_SOURCE_DIR}/thirdparty/flex>
+)
+
+target_link_libraries(flexbisonlib.ebnfparser ebnfastlib)
 
 enable_testing()

--- a/src/grammar/CMakeLists.txt
+++ b/src/grammar/CMakeLists.txt
@@ -26,21 +26,23 @@ target_compile_definitions(flexbisonlib.ebnfparser PRIVATE $<$<PLATFORM_ID:CYGWI
 
 target_compile_options(flexbisonlib.ebnfparser PRIVATE
   $<$<CXX_COMPILER_ID:GNU>: -std=c++26 -Wall -Werror -Wextra -pthread -fconcepts-diagnostics-depth=10>
-  $<$<CXX_COMPILER_ID:MSVC>: -std:c++latest -W4 -WX>
+  $<$<CXX_COMPILER_ID:Clang>: -Wall -Werror -Wextra -std=c++26 -pthread -Wno-unqualified-std-cast-call>
 )
 target_compile_options(flexbisonlib.ebnfparser PRIVATE
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:GNU>>: -O0 -ggdb3>
   $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:GNU>>: -Og>
-  $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:MSVC>>: -Od -Zi>
+  $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:Clang>>: -O0 -ggdb3>
+  $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:Clang>>: -Og>
 )
 
 message("flexbisonlib: flex include dirs \"${FLEX_INCLUDE_DIRS}\"")
 
 target_include_directories(flexbisonlib.ebnfparser PUBLIC ${CMAKE_SOURCE_DIR}/src ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(flexbisonlib.ebnfparser PUBLIC
-  $<$<CXX_COMPILER_ID:MSVC>: ${CMAKE_SOURCE_DIR}/thirdparty/flex>
   $<$<PLATFORM_ID:Darwin>: ${FLEX_INCLUDE_DIRS}>
 )
+
+target_link_libraries(flexbisonlib.ebnfparser ebnfastlib)
 
 add_custom_command(TARGET flexbisonlib.ebnfparser POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/ebnf_grammar_report.txt ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/src/lexer/CMakeLists.txt
+++ b/src/lexer/CMakeLists.txt
@@ -9,11 +9,14 @@ target_compile_definitions(ebnf_lexer.gtest PRIVATE $<$<PLATFORM_ID:CYGWIN>: GTE
 target_compile_options(ebnf_lexer.gtest PRIVATE
   $<$<CXX_COMPILER_ID:GNU>: -Wall -Werror -Wextra -std=c++26 -pthread -fconcepts-diagnostics-depth=10>
   $<$<CXX_COMPILER_ID:MSVC>: -std:c++latest -W4 -WX>
+  $<$<CXX_COMPILER_ID:Clang>: -Wall -Werror -Wextra -std=c++26 -pthread -Wno-unqualified-std-cast-call>
 )
 target_compile_options(ebnf_lexer.gtest PRIVATE
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:GNU>>: -O0 -ggdb3>
   $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:GNU>>: -Og>
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:MSVC>>: -Od -Zi>
+  $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:Clang>>: -O0 -ggdb3>
+  $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:Clang>>: -Og>
 )
 
 target_link_libraries(ebnf_lexer.gtest flexbisonlib.ebnfparser gmock_main)

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -9,14 +9,17 @@ target_compile_definitions(ebnfparser PRIVATE $<$<PLATFORM_ID:CYGWIN>: GTEST_HAS
 target_compile_options(ebnfparser PRIVATE
   $<$<CXX_COMPILER_ID:GNU>: -Wall -Werror -Wextra -std=c++26 -pthread -fconcepts-diagnostics-depth=10>
   $<$<CXX_COMPILER_ID:MSVC>: -std:c++latest -W4 -WX>
+  $<$<CXX_COMPILER_ID:Clang>: -Wall -Werror -Wextra -std=c++26 -pthread -Wno-unqualified-std-cast-call>
 )
 target_compile_options(ebnfparser PRIVATE
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:GNU>>: -O0 -ggdb3>
   $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:GNU>>: -Og>
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:MSVC>>: -Od -Zi>
+  $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:Clang>>: -O0 -ggdb3>
+  $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:Clang>>: -Og>
 )
 
-target_link_libraries(ebnfparser flexbisonlib.ebnfparser)
+target_link_libraries(ebnfparser ebnfastlib flexbisonlib.ebnfparser)
 target_link_libraries(ebnfparser $<$<CXX_COMPILER_ID:MSVC>: getoptlib>)
 
 # tests
@@ -28,14 +31,17 @@ target_compile_definitions(ebnf_parser.gtest PRIVATE $<$<PLATFORM_ID:CYGWIN>: GT
 target_compile_options(ebnf_parser.gtest PRIVATE
   $<$<CXX_COMPILER_ID:GNU>: -Wall -Werror -Wextra -std=c++26 -pthread -fconcepts-diagnostics-depth=10>
   $<$<CXX_COMPILER_ID:MSVC>: -std:c++latest -W4 -WX>
+  $<$<CXX_COMPILER_ID:Clang>: -Wall -Werror -Wextra -std=c++26 -pthread -Wno-unqualified-std-cast-call>
 )
 target_compile_options(ebnf_parser.gtest PRIVATE
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:GNU>>: -O0 -ggdb3>
   $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:GNU>>: -Og>
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:MSVC>>: -Od -Zi>
+  $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:Clang>>: -O0 -ggdb3>
+  $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:Clang>>: -Og>
 )
 
-target_link_libraries(ebnf_parser.gtest flexbisonlib.ebnfparser gmock_main)
+target_link_libraries(ebnf_parser.gtest ebnfastlib flexbisonlib.ebnfparser gmock_main)
 
 enable_testing()
 include(GoogleTest)

--- a/src/parser_api/CMakeLists.txt
+++ b/src/parser_api/CMakeLists.txt
@@ -9,11 +9,14 @@ target_compile_definitions(ebnfparse PRIVATE $<$<PLATFORM_ID:CYGWIN>: _POSIX_C_S
 target_compile_options(ebnfparse PRIVATE
   $<$<CXX_COMPILER_ID:GNU>: -Wall -Werror -Wextra -std=c++26 -pthread -fconcepts-diagnostics-depth=10>
   $<$<CXX_COMPILER_ID:MSVC>: -std:c++latest -W4 -WX>
+  $<$<CXX_COMPILER_ID:Clang>: -Wall -Werror -Wextra -std=c++26 -pthread -Wno-unqualified-std-cast-call>
 )
 target_compile_options(ebnfparse PRIVATE
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:GNU>>: -O0 -ggdb3>
   $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:GNU>>: -Og>
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:MSVC>>: -Od -Zi>
+  $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:Clang>>: -O0 -ggdb3>
+  $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:Clang>>: -Og>
 )
 
 target_link_libraries(ebnfparse flexbisonlib.ebnfparser)
@@ -28,14 +31,17 @@ target_compile_definitions(ebnf_parse.gtest PRIVATE $<$<PLATFORM_ID:CYGWIN>: GTE
 target_compile_options(ebnf_parse.gtest PRIVATE
   $<$<CXX_COMPILER_ID:GNU>: -Wall -Werror -Wextra -std=c++26 -pthread -fconcepts-diagnostics-depth=10>
   $<$<CXX_COMPILER_ID:MSVC>: -std:c++latest -W4 -WX>
+  $<$<CXX_COMPILER_ID:Clang>: -Wall -Werror -Wextra -std=c++26 -pthread -Wno-unqualified-std-cast-call>
 )
 target_compile_options(ebnf_parse.gtest PRIVATE
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:GNU>>: -O0 -ggdb3>
   $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:GNU>>: -Og>
   $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:MSVC>>: -Od -Zi>
+  $<$<AND:$<CONFIG:debug>,$<CXX_COMPILER_ID:Clang>>: -O0 -ggdb3>
+  $<$<AND:$<CONFIG:release>,$<CXX_COMPILER_ID:Clang>>: -Og>
 )
 
-target_link_libraries(ebnf_parse.gtest flexbisonlib.ebnfparser gmock_main)
+target_link_libraries(ebnf_parse.gtest ebnfastlib flexbisonlib.ebnfparser gmock_main)
 
 enable_testing()
 include(GoogleTest)

--- a/src/parser_api/ebnf_parse.h
+++ b/src/parser_api/ebnf_parse.h
@@ -64,7 +64,7 @@ struct Ebnf {
 
   expected<Bnf, int> convert() {
     EbnfConvert ebnf;
-    return Bnf{move(ebnf.convert(root))};
+    return Bnf{ebnf.convert(root)};
   }
 
 };

--- a/src/wasm/CMakeLists.txt
+++ b/src/wasm/CMakeLists.txt
@@ -1,0 +1,22 @@
+# wasm/CMakeLists.txt
+
+# webassembly cmakefile
+
+cmake_minimum_required(VERSION 4.2)
+project(ebnfparser_wasm CXX)
+
+set(CMAKE_CXX_STANDARD 26)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_executable(ebnfparse_wasm ../src/parser_api/ebnf_parse.cpp)
+
+target_link_options(ebnfparse_wasm PRIVATE
+    "--bind"
+    "-sMODULARIZE=1"
+    "-sEXPORT_ES6=1"
+    "-sENVIRONMENT=node,web"
+    "-sFILESYSTEM=0"
+    "-O3"
+)
+
+set_target_properties(ebnfparse_wasm PROPERTIES SUFFIX ".mjs")


### PR DESCRIPTION
 also add empty_bases attribute to nested overloads to fix windows crash